### PR TITLE
Update README.md about host_url

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Add a new resource type to your Concourse CI pipeline:
 ## Source Configuration
 
 * `host_url`: *Required.* The address of the SonarQube instance,
-  e.g. "https://sonarcloud.io/" (when using SonarCloud). Must end with a slash.
+  e.g. "https://sonarcloud.io/" (when using SonarCloud). Must end with a slash. Also, make sure the Server base URL under Administration-> Configuration -> General Settings -> Server base URL of SonarQube instance is same as the sonarqube instance host url. 
 
 * `organization`: The organization to be used when submitting stuff to a sonarqube
   instance. This field is *required* when using SonarCloud to perform the analysis


### PR DESCRIPTION
I added the comment as I faced below issue. 
I was using a sandbox instance of sonarqube which had different host name than production version. But as the sandbox was cloned from production, the Server base URL remained same. When the analysis was performed, the sonar runner printed following in the logs
Actual: 
ce_task_url	http://prod-sonarqube.com:9009/api/ce/task?id=AWG6njze0E05u_gH2XqY
dashboard_url	http://prod-sonarqube.com:9009/dashboard/index/lib_app
project_key	lib_app
scanner_type	cli
server_url	http://prod-sonarqube.com:9009
server_version	6.7.0.33306

Expected:
ce_task_url	http://sandbox-sonarqube.com:9009/api/ce/task?id=AWG6njze0E05u_gH2XqY
dashboard_url	http://sandbox-sonarqube.com:9009/dashboard/index/lib_app
project_key	lib_app
scanner_type	cli
server_url	http://sandbox-sonarqube.com:9009
server_version	6.7.0.33306

This was due to the Server base URL configuration. This could very well be sonarqube scanner cli issue but the logs in concourse were misleading, pointing to wrong instance. Usually the instance may not be even configured with correct host name as it is only used to create email links.